### PR TITLE
fix tags filter to retrieve specified tags not excluding specified tags

### DIFF
--- a/pypingdom/client.py
+++ b/pypingdom/client.py
@@ -43,7 +43,7 @@ class Client(object):
 
     def get_checks(self, filters=None):
         if filters is None:
-            filters = {}
+            return [c for c in self.checks.values()]
         return [c for c in self.checks.values() if not len(set(filters.get("tags", [])).intersection(set([x['name']
                 for x in c.tags]))) == 0]
 

--- a/pypingdom/client.py
+++ b/pypingdom/client.py
@@ -44,7 +44,7 @@ class Client(object):
     def get_checks(self, filters=None):
         if filters is None:
             filters = {}
-        return [c for c in self.checks.values() if len(set(filters.get("tags", [])).intersection(set([x['name']
+        return [c for c in self.checks.values() if not len(set(filters.get("tags", [])).intersection(set([x['name']
                 for x in c.tags]))) == 0]
 
     def create_check(self, name, obj):

--- a/pypingdom/tests/test_client.py
+++ b/pypingdom/tests/test_client.py
@@ -70,4 +70,4 @@ class ClientTestCase(unittest.TestCase):
         self.assertTrue(all(isinstance(x, Check) for x in res))
 
         res = client.get_checks(filters={"tags": ['apache']})
-        self.assertEqual(len(res), 2)
+        self.assertEqual(len(res), 1)


### PR DESCRIPTION
When filter by tags, the intersection between the tags specified on the and the tags from the check needs to be different than 0. 