### PR TITLE
extra condition to avoid print info of NoneType object

### DIFF
--- a/pypingdom/maintenance.py
+++ b/pypingdom/maintenance.py
@@ -36,7 +36,7 @@ class Maintenance(object):
                    ", ".join(checks))
 
     def to_json(self):
-        check_ids = [str(check._id) for check in self.checks]
+        check_ids = [str(check._id) for check in self.checks if check]
         data = {
             # "__csrf_magic": "",
             # "id": "",


### PR DESCRIPTION
Fix error `AttributeError: 'NoneType' object has no attribute '_id'` when printing maintenance window information. 