### PR TITLE
Fix create_check documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,10 +122,10 @@ Create a check:
             "requestheaders": {
                 'XCustom': 'my header value'
             },
-            "tags": ["pypingdom-test", "custom-tag"],
+            "tags": [{"name": "pypingdom-test"}, {"name": "custom-tag"}],
             "encryption": False
         }
-    >>> client.update_check(check, check_definition)
+    >>> client.create_check('My awesome check', check_definition)
 
 
 Refers to `this page <https://www.pingdom.com/resources/api#MethodCreate+New+Check>`_ for the list of options.


### PR DESCRIPTION
After playing around with the package and trying to make it work, Seems to me that the README is wrong in relation with code expectations for the create and update method, as you can see below

https://github.com/sekipaolo/pypingdom/blob/e6824f5fa619d09e846a037ad88070372b1baef9/pypingdom/check.py#L36

That lambda functions that process pingdom `tags` is waiting for dictionary objects but the documentation shows a list of strings is necessary instead, I didn't dig further on the code but I was able to make all stuff to work by using a list of dictionaries with a key `name` for tags instead of list of strings,  still I could be missing something important

Also the update_check method is shown under create_check section, 

Thanks