### PR TITLE
Decode response in ApiError Exception to avoid json load error in python3

### DIFF
--- a/pypingdom/api.py
+++ b/pypingdom/api.py
@@ -9,7 +9,7 @@ from requests.auth import HTTPBasicAuth
 class ApiError(Exception):
 
     def __init__(self, http_response):
-        content = json.loads(http_response.content)
+        content = json.loads(http_response.content.decode('utf-8'))
         self.status_code = http_response.status_code
         self.status_desc = content['error']['statusdesc']
         self.error_message = content['error']['errormessage']

--- a/pypingdom/api.py
+++ b/pypingdom/api.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import json
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -9,7 +8,7 @@ from requests.auth import HTTPBasicAuth
 class ApiError(Exception):
 
     def __init__(self, http_response):
-        content = json.loads(http_response.content.decode('utf-8'))
+        content = http_response.json()
         self.status_code = http_response.status_code
         self.status_desc = content['error']['statusdesc']
         self.error_message = content['error']['errormessage']


### PR DESCRIPTION
Hi,
I just noticed that ApiError Exception fails in python3 (tested in python 3.5.2) when trying to `json.load` the response

https://github.com/sekipaolo/pypingdom/blob/cc4ea299a7bf789b81f8b3bea8d834d910cb3541/pypingdom/api.py#L12

The Exception itself raises another exception

```
TypeError: the JSON object must be str, not 'bytes'
```

You can reproduce the error by doing (Note that the version argument is wrong)

```
import unittest
import pypingdom

class TestPingdom(unittest.TestCase):

    def test_request(self):
        client = pypingdom.Client(
            apikey='xxxxx',
            username='xxxxx',
            password='xxxxx',
            email='xxxxx',
            api_version='2,1'
        )
        client.get_checks()
        # Should Raise a 404 ApiError exception but the
        # exception itself throws an "TypeError: the JSON object must be str, not 'bytes'" exception
        self.assertRaises(pypingdom.api.ApiError)

if __name__ == '__main__':
    unittest.main()
```
Apparently by only decoding the response this works, in both python2 and python3