### PR TITLE
Add "check_certificate" to list of ignored fields

### DIFF
--- a/pypingdom/check.py
+++ b/pypingdom/check.py
@@ -7,7 +7,7 @@ class Check(object):
     SKIP_ON_PRINT = ["cached_definition", "_id", "api"]
     SKIP_ON_JSON = [
         "api", "alert_policy_name", "cached_definition", "created", "lastresponsetime",
-        "lasttesttime", "lasterrortime", "_id", "id", "status", "maintenanceids"
+        "lasttesttime", "lasterrortime", "_id", "id", "status", "maintenanceids", "check_certificate"
     ]
 
     def __init__(self, api, json=False, obj=False):


### PR DESCRIPTION
Pingdom API now returns "check_certificate" with the list of checks but this field is rejected when attempting to update a check.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/miniconda3/lib/python3.6/site-packages/pypingdom/client.py", line 75, in update_check
    self.api.send(method='put', resource='checks', resource_id=check._id, data=data)
  File "/data/miniconda3/lib/python3.6/site-packages/pypingdom/api.py", line 52, in send
    raise ApiError(response)
pypingdom.api.ApiError: pingdom.ApiError: HTTP `400 - Bad Request` returned with message, "Invalid parameter value: check_certificate"
```