### PR TITLE
update_check: Remove 'verify_certificate' of non-http check params

### DIFF
--- a/pypingdom/client.py
+++ b/pypingdom/client.py
@@ -71,6 +71,10 @@ class Client(object):
         data = check.to_json()
         if data == cached_definition:
             return False
+        if check.type != 'http':
+            # GET /checks (get_checks) returns 'verify_certificate' regardless
+            # check type. Remove from PUT data for non http checks
+            del data['verify_certificate']
         del data["type"]  # type can't be changed
         self.api.send(method='put', resource='checks', resource_id=check._id, data=data)
         check.from_json(self.api.send('get', "checks", check._id)['check'])


### PR DESCRIPTION
The following sequence, for an existing *non* http check, fails:

    chk = client.get_check(name='testcheck')
    client.update_check(chk, some_update_params)

With the error 400 'Invalid parameter: verify_certificate'.

This is since 'verify_certificate' field is always present when issuing
GET /checks.

Sanitize the data passed to PUT /checks/{check_id} by stripping the
'verify_certificate' parameter for non-http checks.