### PR TITLE
patch verify_certificate/encryption bug

### DIFF
--- a/pypingdom/client.py
+++ b/pypingdom/client.py
@@ -75,7 +75,6 @@ class Client(object):
         if check.type == 'http':
             # The http-type API will only accept a parameter called 'encryption' though.
             data['encryption'] = changes['encryption'] if 'encryption' in changes else data['verify_certificate']
-            print(data['encryption'])
         del data['verify_certificate']  # 'verify_certificate' is not a valid parameter
         del data["type"]  # type can't be changed
         self.api.send(method='put', resource='checks', resource_id=check._id, data=data)

--- a/pypingdom/client.py
+++ b/pypingdom/client.py
@@ -76,7 +76,7 @@ class Client(object):
             # The http-type API will only accept a parameter called 'encryption' though.
             data['encryption'] = changes['encryption'] if 'encryption' in changes else data['verify_certificate']
             print(data['encryption'])
-        del data['verify_certificate'] # 'verify_certificate' is not a valid parameter
+        del data['verify_certificate']  # 'verify_certificate' is not a valid parameter
         del data["type"]  # type can't be changed
         self.api.send(method='put', resource='checks', resource_id=check._id, data=data)
         check.from_json(self.api.send('get', "checks", check._id)['check'])

--- a/pypingdom/client.py
+++ b/pypingdom/client.py
@@ -71,10 +71,12 @@ class Client(object):
         data = check.to_json()
         if data == cached_definition:
             return False
-        if check.type != 'http':
-            # GET /checks (get_checks) returns 'verify_certificate' regardless
-            # check type. Remove from PUT data for non http checks
-            del data['verify_certificate']
+        # GET /checks (get_checks) returns 'verify_certificate' regardless
+        if check.type == 'http':
+            # The http-type API will only accept a parameter called 'encryption' though.
+            data['encryption'] = changes['encryption'] if 'encryption' in changes else data['verify_certificate']
+            print(data['encryption'])
+        del data['verify_certificate'] # 'verify_certificate' is not a valid parameter
         del data["type"]  # type can't be changed
         self.api.send(method='put', resource='checks', resource_id=check._id, data=data)
         check.from_json(self.api.send('get', "checks", check._id)['check'])


### PR DESCRIPTION
When getting a check, pingdom returns `verify_certificate` instead of `encryption` for the check-ssl key.

However `update` api call only accepts `encryption` and will error with `verify_certificate`,

So replace `verify_certificate` with `encryption` in the returned check,