### PR TITLE
API Class rework for Pingdom Api Version 3.1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Contributors
 Paolo Sechi (https://github.com/sekipaolo)
 Paul Kremer (https://github.com/infothrill)
 Kristofer Borgström (https://github.com/kribor)
+Lucas Nicolaus (https://github.com/TheLegendaryAdmin)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -19,3 +19,8 @@
 * added changelog
 * switched legacy, unsupported maintenance window getter to supported rest
   api method
+
+0.3.0
+=====
+* adjusted API class to work with new Pingdom API 3.1
+* introcuded typing to constructors

--- a/pypingdom/api.py
+++ b/pypingdom/api.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import requests
 from requests.auth import HTTPBasicAuth
-from packaging import version
 
 
 class ApiError(Exception):
@@ -25,16 +24,14 @@ class ApiError(Exception):
 
 class Api(object):
 
-    def __init__(self, username, password, apikey, email=False, apiversion="2.0"):
-        self.base_url = "https://api.pingdom.com/api/" + apiversion + "/"
-        if version.parse(apiversion) < version.parse('3.0'):
-            self.auth = HTTPBasicAuth(username, password)
-            self.headers = {'App-Key': apikey}
-            if email:
-                self.headers['Account-Email'] = email
-        else:
-            self.headers = {'Authorization': 'Bearer ' + apikey}
-            self.auth = None
+    def __init__(self, apikey: str, email: str =False, version: str="3.1"):
+        # self.auth = HTTPBasicAuth(username, password)
+        self.base_url = "https://api.pingdom.com/api/" + str(version) + '/'
+        self.headers = {'Authorization': 'Bearer ' + str(apikey),
+        'Host': 'api.pingdom.com',
+        "Connection": "keep-alive", "Cache-Control": "no-cache"}
+        if email:
+            self.headers['Account-Email'] = email
 
     def send(self, method, resource, resource_id=None, data=None, params=None):
         if data is None:
@@ -43,8 +40,9 @@ class Api(object):
             params = {}
         if resource_id is not None:
             resource = "%s/%s" % (resource, resource_id)
+        if method != 'get' and data is not None:
+            self.headers["Content-Type"]: "application/json"
         response = requests.request(method, self.base_url + resource,
-                                    auth=self.auth,
                                     headers=self.headers,
                                     data=data,
                                     params=params

--- a/pypingdom/client.py
+++ b/pypingdom/client.py
@@ -10,7 +10,7 @@ from .maintenance import Maintenance
 class Client(object):
     """Interact with API and GUI."""
 
-    def __init__(self, username, password, apikey, email, api_version='2.0'):
+    def __init__(self, username:str , password: str, apikey: str, email: str, api_version: str='3.1'):
         """
         Initializer.
 
@@ -20,7 +20,11 @@ class Client(object):
         :param email: required for `Multi-User Authentication
                       <https://www.pingdom.com/resources/api#multi-user+authentication>`_.
         """
-        self.api = Api(username, password, apikey, email, api_version)
+        self.username = username
+        self.password = password
+        self.apikey = apikey
+        self.email = email
+        self.api = Api(apikey, email, api_version)
         self.gui = Gui(username, password)
         # cache checks
         self.checks = {}
@@ -40,9 +44,8 @@ class Client(object):
     def get_checks(self, filters=None):
         if filters is None:
             return [c for c in self.checks.values()]
-
-        return [c for c in self.checks.values() if len(set(u + filters.get("status", c.status)
-                for u in filters.get("tags", [])).intersection(set([x['name'] + c.status for x in c.tags])))]
+        return [c for c in self.checks.values() if not len(set(filters.get("tags", [])).intersection(set([x['name']
+                for x in c.tags]))) == 0]
 
     def create_check(self, obj):
         c = Check(self.api, obj=obj)

--- a/pypingdom/gui.py
+++ b/pypingdom/gui.py
@@ -24,7 +24,7 @@ class PingdomGuiException(Exception):
 
 class Gui():
 
-    def __init__(self, username, password):
+    def __init__(self, username: str, password: str):
         self.__username = username
         self.__password = password
         self.session = requests.session()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(BASEDIR, 'README.rst'), 'r') as f:
 
 
 setup(name='pypingdom',
-      version='0.2.2',
+      version='0.3.0',
       description='Client for Pingdom Services',
       long_description=README,
       author='Paolo Sechi',


### PR DESCRIPTION
I wanted to use this package for a project at work and ran into some issues.
It seems like the new generated API Keys are not compatible with older API Versions. For this reason I reworked the API Class so that it is compatible with the Pingdom 3.1 API.
I already tested this in my working environment and did not run into any issues. Feedback is always appreciated and encouraged.

Changes made:
* version increase to 0.3.0
* adjusted API class to work with new Pingdom API 3.1
* dropped required parameters for username and password in API class
* introcuded typing to constructors