### PR TITLE
Fix error when updating checks via Pingdom API.

### DIFF
--- a/pypingdom/check.py
+++ b/pypingdom/check.py
@@ -7,7 +7,8 @@ class Check(object):
     SKIP_ON_PRINT = ["cached_definition", "_id", "api"]
     SKIP_ON_JSON = [
         "api", "alert_policy_name", "cached_definition", "created", "lastresponsetime",
-        "lasttesttime", "lasterrortime", "_id", "id", "status", "maintenanceids"
+        "lasttesttime", "lasterrortime", "lastdownstart", "lastdownend",
+        "_id", "id", "status", "maintenanceids"
     ]
 
     def __init__(self, api, json=False, obj=False):


### PR DESCRIPTION
Apparently pingdom checks now output additional params `lastdownstart`
and `lastdownend` which the api is unable to handle as arguments.

Solves the following error:
```
Traceback (most recent call last):
...
  File "/home/gerloffokkema/.local/lib/python3.8/site-packages/pypingdom/client.py", line 81, in update_check
    self.api.send(method='put', resource='checks', resource_id=check._id, data=data)
  File "/home/gerloffokkema/.local/lib/python3.8/site-packages/pypingdom/api.py", line 48, in send
    raise ApiError(response)
pypingdom.api.ApiError: pingdom.ApiError: HTTP `400 - Bad Request` returned with message, "Invalid parameter: lastdownend."
```